### PR TITLE
feat: Add two new security reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ To add new incidents use the date of the event as the Id with the following form
 - [2023-10-03](incidents/2023-10-03.md) Marketplace search not working
 
 ## Vulnerabilities Index
+
+- [2025-05-26](vulnerabilities/2025-05-26.md) Cache poisoning through WAF and a big amount of headers
+- [2025-05-23](vulnerabilities/2025-05-23.md) Blocking users through cookie poisoning and WAF
 - [2025-02-27](vulnerabilities/2025-02-27.md) AWS Key Exposed
 - [2025-01-07](vulnerabilities/2025-01-07.md) Temp Atlas Server DoS
 - [2024-12-25](vulnerabilities/2024-12-25.md) Ability leaks the IP address and user agent of the other user

--- a/vulnerabilities/2025-05-23.md
+++ b/vulnerabilities/2025-05-23.md
@@ -1,0 +1,23 @@
+# Apr-27-2025 - Blocking users through cookie poisoning and WAF
+
+|                          |             |
+| -----------------------: | :---------- |
+| **Reported on Immunefi** | Apr-27-2025 |
+|           **Mitigation** | May-23-2025 |
+|   **Solution Completed** | May-23-2025 |
+
+## Description
+
+A link to sites hosted as Cloudflare Pages that used the Facebook pixel could be crafted so the `:javascript` string ended up being used as a cookie, which upon being sent to any of our sites, resulted in the user being blocked by Cloudflare's WAF.
+
+We've identified this as a Cloudflare bug, as there's an inconsistency between how the WAF rules are applied to query string and cookies, where the string `:javascript` was not blocked when used as a query string but gets blocked when used as cookie.
+
+Users that opened these types of links would have required to clear the site's cookies in order to remove the block.
+
+## Severity
+
+Websites & Applications - Low.
+
+## Solution
+
+We've implemented a WAF rule to prevent any requests from containing a query parameter with `:javascript` in them.

--- a/vulnerabilities/2025-05-26.md
+++ b/vulnerabilities/2025-05-26.md
@@ -1,0 +1,23 @@
+# May-26-2025 - Cache poisoning through WAF and a big amount of headers
+
+|                          |             |
+| -----------------------: | :---------- |
+| **Reported on Immunefi** | May-21-2025 |
+|           **Mitigation** | May-26-2025 |
+|   **Solution Completed** | May-26-2025 |
+
+## Description
+
+When doing an HTTP request to a Cloudflare Page asset that can be cached by Cloudflare, if the request contains an amount of headers bigger than what Cloudflare is willing to process with a WAF blocked header as the last of them, Cloudflare returned the classic WAF blocked page and cached it for 15 seconds. This cached page is seen by everyone that connects to the node until the cache expires.
+
+We've identified this as a Cloudflare bug, as this is exploitable under the default Cloudflare Page + WAF configuration.
+
+The bug is exploitable only in nodes that don't have the exploited HTTP request cached or in which the cache is expired and would require a coordinated attack of bots connected in different regions.
+
+## Severity
+
+Websites & Applications - Low.
+
+## Solution
+
+We've implemented a WAF rule to prevent any request with a big amount of headers.


### PR DESCRIPTION
This PR adds two new security reports:
- Cache poisoning through WAF and a big amount of headers
- Blocking users through cookie poisoning and WAF