### PR TITLE
docs: RCA 2026-06-08 worlds parcel-restricted deploy escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To add new incidents use the date of the event as the Id with the following form
 - [2022-02-05](incidents/2022-02-05.md) Wearables not loading on some users backpack due to corrupted dropped wearable
 
 ## Vulnerabilities Index
+- [2026-06-08](vulnerabilities/2026-06-08.md) Parcel-restricted world collaborator can deploy to and delete scenes across the entire world
 - [2026-05-18](vulnerabilities/2026-05-18.md) Prompt injection in unity-explorer Claude PR review workflow
 - [2026-04-07](vulnerabilities/2026-04-07.md) Any Authenticated User Can Modify or Permanently Delete Any Event
 - [2026-03-04](vulnerabilities/2026-03-04.md) Unauthenticated newsletter unsubscription of other users

--- a/vulnerabilities/2026-06-08.md
+++ b/vulnerabilities/2026-06-08.md
@@ -1,0 +1,26 @@
+# June 8, 2026 - Parcel-restricted world collaborator can deploy to and delete scenes across the entire world
+
+|                          |              |
+| -----------------------: | :----------- |
+| **Reported on Immunefi** | June-06-2026 |
+|           **Mitigation** | June-08-2026 |
+|   **Solution Completed** | June-08-2026 |
+
+## Description
+
+- A world owner can grant another wallet deployment permission restricted to specific parcels (e.g. "you may deploy on `0,0`, nothing else"). This is an intended collaborator/operator role set through the Builder, and the [publishing docs](https://docs.decentraland.org/creator/scenes-sdk7/publishing/publishing) present it as contained: an operator with rights on specific parcels can only publish to those parcels and cannot affect content on the rest of the world.
+- That containment did not hold in the World Content Server (`worlds-content-server.decentraland.org`). On deployment, the server authorized the request against one field, `entity.pointers`, but stored the scene — and soft-deleted whatever scenes already overlapped those coordinates — using a different field, `entity.metadata.scene.parcels`. Both fields sit inside the same signed entity file and are fully chosen by whoever builds the deployment, and nothing in the code or in the pinned `@dcl/schemas` validator required the two to be equal.
+- A collaborator restricted to `0,0` could therefore send `pointers: ["0,0"]` to pass the permission check, and `scene.parcels: ["10,10","10,11"]` to decide where the scene actually landed. The server published the collaborator's scene to `10,10`/`10,11` and undeployed whatever the owner (or another collaborator) had there. The least-privileged deploy role became effective whole-world deploy control.
+- Impact for a wallet holding only a single-parcel grant:
+  - **Whole-world deploy control.** With `pointers` set to its one granted parcel and `scene.parcels` set to anything, the collaborator could publish arbitrary scene content to any parcel of the world, rendered to every visitor.
+  - **Destruction of other users' content.** The overlap delete at `worlds-manager.ts:262` flips every overlapping `DEPLOYED` scene to `UNDEPLOYED`, including scenes deployed by the world owner or other collaborators. Undeployed scenes are permanently evicted after `SCENE_EVICTION_TTL_MS` (default `604800000` ms = 7 days), making the loss irreversible.
+  - **Per-world parcel-limit bypass.** The limit was enforced on `entity.pointers.length` (`scene.ts:100`) while real occupancy came from `metadata.scene.parcels`, so small `pointers` plus large `scene.parcels` let a collaborator occupy more parcels than the world's allowance.
+- Precondition: the attacker must already hold a parcel-restricted deployment grant on the target world — a normal collaborator role that the docs present as safe and contained.
+
+## Severity
+
+Websites & Applications - Medium.
+
+## Solution
+
+[Make the authorized field and the stored field the same set of parcels](https://github.com/decentraland/worlds-content-server/pull/486). A new `validateScenePointers` validation rejects any deployment where `entity.pointers` and `entity.metadata.scene.parcels` do not reference the same set of parcels, and the deployment's target parcels are now derived from `entity.pointers` (the field used for authorization) as the single source of truth — so the permission check, the scene placement, the overlap-based undeploy, and the parcel-limit/quota accounting all operate on the same parcels. Parcels are canonicalized everywhere (e.g. `00,00` == `0,0`) so a non-canonical value can no longer dodge the equality check or the overlap replacement.


### PR DESCRIPTION
Adds the RCA for the World Content Server vulnerability reported on Immunefi (June 6, 2026) and fixed/deployed June 8, 2026.

## Summary
A world owner can grant a wallet deployment permission restricted to specific parcels (an intended collaborator role the publishing docs present as contained). The containment did not hold: the server authorized deployments against `entity.pointers` but stored the scene — and soft-deleted overlapping scenes — using `entity.metadata.scene.parcels`. Since both fields are attacker-chosen and the code never required them to match, a collaborator restricted to one parcel could pass the permission check on that parcel while placing/overwriting scenes anywhere in the world.

## Impact
- Whole-world deploy control from a single-parcel grant
- Destruction of other users' content via the overlap soft-delete (permanent after 7-day eviction TTL)
- Per-world parcel-limit bypass

## Severity
Websites & Applications - Medium

## Fix
[worlds-content-server#486](https://github.com/decentraland/worlds-content-server/pull/486) — adds a `validateScenePointers` check requiring `entity.pointers` and `scene.parcels` to reference the same canonicalized parcel set, and derives the deployment's target parcels from `entity.pointers` as the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)