### PR TITLE
docs: RCA 2026-06-18 Node.js security patch broke node-fetch v2 (Premature close)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To add new incidents use the date of the event as the Id with the following form
 
 ## Incidents Index
 
+- [2026-06-18](incidents/2026-06-18.md) Mass service request failures ("Premature close") after Node.js security patch hardened keep-alive socket pooling
 - [2026-05-04](incidents/2026-05-04.md) Intermittent Crashing in Genesis Plaza (Part #2)
 - [2026-04-17](incidents/2026-04-17.md) Intermittent Crashing in Genesis Plaza (Mitigation)
 - [2026-03-17](incidents/2026-03-17.md) Users unable to login with Crypto wallets / Magic options

--- a/incidents/2026-06-18.md
+++ b/incidents/2026-06-18.md
@@ -4,7 +4,7 @@
 | -----------------------: | :------------ |
 |    **Reported on Slack** | June 18, 2026 |
 |           **Mitigation** | June 18, 2026 |
-|   **Solution Completed** | June 18, 2026 |
+|   **Solution Completed** | Pending       |
 
 ## What happened?
 

--- a/incidents/2026-06-18.md
+++ b/incidents/2026-06-18.md
@@ -1,0 +1,93 @@
+# June 18, 2026 - Mass service request failures ("Premature close") after Node.js security patch hardened keep-alive socket pooling
+
+|                          |               |
+| -----------------------: | :------------ |
+|    **Reported on Slack** | June 18, 2026 |
+|           **Mitigation** | June 18, 2026 |
+|   **Solution Completed** | June 18, 2026 |
+
+## What happened?
+
+On June 18, 2026, the Node.js project published a security release patching several
+high-severity vulnerabilities. Following our standard practice of applying security
+updates promptly, almost all of our backend services were rebuilt on the patched
+Node.js runtime and redeployed during the evening rollout.
+
+Shortly after the rollout began (~19:00 ART), services started failing on **outbound
+HTTP requests**: calls to internal and third-party APIs began rejecting with
+`Premature close` errors, producing cascading failures across nearly the entire
+platform. The incident was formally opened at 19:30 ART (22:30 UTC) and mitigated by
+20:44 ART (23:44 UTC) by rolling every affected service back to its previous image,
+which ran on the unpatched Node.js version.
+
+## Why did it happen?
+
+The failures were not caused by the security fixes themselves, but by a behavioral
+change they carried. The release included a hardening of the keep-alive socket pool in
+Node's HTTP client (upstream: *"http: fix response queue poisoning in `http.Agent`"*),
+which changed the **timing** of when a pooled keep-alive socket is recycled relative to
+when the response body on that socket has finished being read.
+
+Our services performed HTTP requests through an old version of the `cross-fetch`
+package, which on Node.js resolves to **`node-fetch` v2**. When a response is
+gzip-encoded, node-fetch v2 pipes the body through a `Gunzip` (zlib) stream and attaches
+a watcher that errors if the underlying socket closes before the body stream ends
+cleanly. With the patched runtime's new socket-pool timing, a reused socket now closes
+earlier from the response stream's perspective, so that watcher fires and node-fetch v2
+raises a `FetchError: ... Premature close` from inside the gzip handler. The errors
+looked like this:
+
+```
+FetchError: Invalid response body while trying to fetch https://rpc.decentraland.org/mainnet?project=worlds-content-server: Premature close
+    at Gunzip.<anonymous> (/app/node_modules/node-fetch/lib/index.js:400:12)
+```
+
+The failure reproduces specifically under the combination of: a **keep-alive agent
+reusing sockets**, **gzip-encoded responses**, larger response bodies, and request
+concurrency around `maxSockets`. That profile matched our high-volume RPC traffic to
+`rpc.decentraland.org/mainnet` almost exactly, so the breakage was immediate and
+widespread once services moved onto the patched runtime.
+
+Two factors made this hard to spot at first:
+
+- **Our application code and dependencies did not change** — only the runtime's
+  socket-pool timing shifted underneath us, so the same code that worked for years
+  began failing.
+- **`node-fetch` v2 is effectively unmaintained**, so there is no upstream patch to
+  pick up; the package keeps the older premature-close detection that the new Node
+  timing trips. This behavior is tracked upstream in
+  [nodejs/node#63989](https://github.com/nodejs/node/issues/63989).
+
+## Issue Timeline - UTC
+
+1. 2026-06-18 - Node.js publishes a security release patching several high-severity vulnerabilities.
+2. 2026-06-18 21:30 (18:30 ART) - Evening rollout begins; nearly all services are rebuilt on the patched Node.js runtime and redeployed.
+3. 2026-06-18 22:00 (19:00 ART) - Services begin failing outbound HTTP requests with `Premature close`; error rates spike across multiple services. Investigation starts.
+4. 2026-06-18 22:15 (19:15 ART) - Errors correlated with the redeploys; failures traced to outbound fetch calls (gzipped responses, e.g. `rpc.decentraland.org/mainnet`) and common to services running the new Node.js version.
+5. 2026-06-18 22:30 (19:30 ART) - Incident formally created.
+6. 2026-06-18 23:00 (20:00 ART) - Rollback to the previous images (unpatched Node.js) begins across affected services.
+7. 2026-06-18 23:44 (20:44 ART) - Rollback completed; all services rolled back, outbound requests recover and error rates return to normal. Incident resolved.
+
+## Impact
+
+- **Severity**: SEV-1
+- **Users affected**: Platform-wide. Nearly all redeployed services lost the ability to make outbound HTTP requests, degrading most user-facing functionality that depends on internal or third-party APIs (notably blockchain RPC calls).
+- **Symptom**: Outbound HTTP requests made through cross-fetch / node-fetch v2 failed with `FetchError: ... Premature close` (thrown from `Gunzip.<anonymous>` in `node-fetch/lib/index.js`), causing cascading failures across services.
+- **Duration**: ~1h44m from first errors (19:00 ART / 22:00 UTC) to full recovery (20:44 ART / 23:44 UTC); ~1h14m from incident creation (19:30 ART) to resolution.
+- **Trigger**: Adoption of the patched Node.js runtime during the evening rollout.
+
+## Solution
+
+The incident was mitigated by rolling back all affected services to their previous
+container images, which run on the pre-patch Node.js version. This restored the prior
+keep-alive socket-pool timing, so node-fetch v2 stopped reporting premature closes and
+outbound requests recovered immediately.
+
+This was a **temporary mitigation**: it leaves the fleet on an unpatched runtime that
+still carries the high-severity vulnerabilities the release fixed. A permanent fix is
+required so we can re-apply the security patch safely (see Preventive Actions).
+
+## Preventive Actions
+
+- **Migrate from node-fetch v2 to native `fetch`** *(pending)* - Replace the old `cross-fetch` / `node-fetch` v2 dependency and move outbound requests to the runtime's built-in `fetch` (Node 18+, backed by `undici`). This is the durable fix: node-fetch v2 is unmaintained and will not be patched for the new socket-pool timing, whereas native fetch tracks the runtime and is exercised by the same security testing.
+- **Add E2E tests for the services** *(pending)* - We currently lack end-to-end tests that exercise real outbound requests (e.g. RPC calls), so a runtime change that broke every service's HTTP path was not caught before production. Add E2E coverage per service that issues real requests through the HTTP client, and run it against runtime/dependency upgrades so this class of regression is caught pre-deploy.


### PR DESCRIPTION
## Summary

Adds the RCA for the **2026-06-18** platform-wide outage and links it from the README Incidents Index.

On 2026-06-18 a Node.js security release (fixing several high-severity vulnerabilities) was rolled out to almost all services. Shortly after, services began failing on outbound HTTP requests with `FetchError: ... Premature close`, cascading across the platform. Mitigated by rolling every affected service back to its previous image on the unpatched Node.js.

## Root cause

The release hardened the keep-alive socket pool in Node's HTTP client (*"http: fix response queue poisoning in `http.Agent`"*), changing the timing of when a pooled socket is recycled vs. when its response body finishes reading. Our services use an old `cross-fetch` → `node-fetch` v2, which pipes gzip responses through a `Gunzip` stream and errors if the socket closes before the body ends cleanly. The new timing trips that check:

```
FetchError: Invalid response body while trying to fetch https://rpc.decentraland.org/mainnet?project=worlds-content-server: Premature close
    at Gunzip.<anonymous> (/app/node_modules/node-fetch/lib/index.js:400:12)
```

It reproduces under keep-alive socket reuse + gzip responses + larger bodies + concurrency — matching our `rpc.decentraland.org/mainnet` traffic. Tracked upstream in [nodejs/node#63989](https://github.com/nodejs/node/issues/63989). `node-fetch` v2 is unmaintained, so there's no upstream fix.

## Impact

- **Severity:** SEV-1 (platform-wide outbound-request failures)
- **Duration:** ~1h44m from first errors (19:00 ART / 22:00 UTC) to full recovery (20:44 ART / 23:44 UTC)

## Preventive actions

- Migrate from node-fetch v2 to native `fetch` (Node 18+ / undici)
- Add E2E tests per service that exercise real outbound requests, run against runtime/dependency upgrades

## Changes

- `incidents/2026-06-18.md` — new RCA
- `README.md` — Incidents Index entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
