### PR TITLE
docs: RCA 2026-07-01 missing friendship state-machine validation (forged friendships + ONLY_FRIENDS voice-gate bypass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ To add new incidents use the date of the event as the Id with the following form
 - [2022-02-05](incidents/2022-02-05.md) Wearables not loading on some users backpack due to corrupted dropped wearable
 
 ## Vulnerabilities Index
+- [2026-07-01](vulnerabilities/2026-07-01.md) Missing state-machine validation lets any user forge non-consensual friendships and bypass the ONLY_FRIENDS voice gate
 - [2026-06-08](vulnerabilities/2026-06-08.md) Parcel-restricted world collaborator can deploy to and delete scenes across the entire world
 - [2026-05-18](vulnerabilities/2026-05-18.md) Prompt injection in unity-explorer Claude PR review workflow
 - [2026-04-07](vulnerabilities/2026-04-07.md) Any Authenticated User Can Modify or Permanently Delete Any Event

--- a/vulnerabilities/2026-07-01.md
+++ b/vulnerabilities/2026-07-01.md
@@ -1,0 +1,24 @@
+# July 1, 2026 - Missing state-machine validation lets any user forge non-consensual friendships and bypass the ONLY_FRIENDS voice gate
+
+|                          |              |
+| -----------------------: | :----------- |
+| **Reported on Immunefi** | June-28-2026 |
+|           **Mitigation** | July-01-2026 |
+|   **Solution Completed** | July-01-2026 |
+
+## Description
+
+- The social service friendship system is a state machine, but `upsertFriendship` (`src/logic/friends/component.ts`) — the single code path behind every friendship action — applied the requested action without validating the transition; its only guard was `isFriendshipBlocked`.
+- The validator that enforces legal transitions, `validateNewFriendshipAction`, existed and was unit-tested, but its only call site had been dropped during the `upsertFriendship` refactor (#214), leaving it as dead code.
+- As a result, any authenticated user could send an `ACCEPT` targeting an arbitrary address with no prior request and create an `is_active = true` friendship on both accounts, mutating another user's social graph with zero interaction or consent.
+- Because the private-voice gate (`startPrivateVoiceChat`) keys solely on `friendship.is_active`, the forged friendship also bypassed a victim's `ONLY_FRIENDS` setting, enabling unsolicited private voice calls. Confirmed live in production against two real accounts, and scales to arbitrary addresses in bulk.
+
+## Severity
+
+Websites & Applications - High.
+
+Reported as Critical (zero-interaction state modification plus a privacy-control bypass); downgraded to High because impact was limited to the friendship request flow.
+
+## Solution
+
+[Enforce the friendship state machine in `upsertFriendship`](https://github.com/decentraland/social-service-ea/pull/427) by wiring the existing `validateNewFriendshipAction` in before any state is written, so illegal transitions (`ACCEPT` with no pending request, accepting your own or an already-active request, etc.) throw `InvalidFriendshipActionError` and no row is created or updated. `InvalidFriendshipActionError` was also moved from `controllers/` into the friends logic `errors.ts` (a logic component must not import from `controllers/`), with the controller still mapping it to the unchanged `invalidFriendshipAction` response.


### PR DESCRIPTION
## Description

Adds the security RCA for the social-service-ea friendship state-machine vulnerability reported on Immunefi (June 28, 2026) and fixed in [social-service-ea#427](https://github.com/decentraland/social-service-ea/pull/427) (merged July 1, 2026).

- `upsertFriendship` — the single code path behind every friendship action — never validated state-machine transitions. `validateNewFriendshipAction` encoded the legal transitions and was unit-tested, but its only call site had been dropped during the `upsertFriendship` refactor (#214), leaving it as dead code.
- Any authenticated user could send an `ACCEPT` targeting an arbitrary address with no prior request and forge an `is_active = true` friendship on both accounts, with zero victim interaction or consent.
- Because the private-voice gate keys solely on `friendship.is_active`, the forged friendship also bypassed a victim's `ONLY_FRIENDS` setting, enabling unsolicited private voice calls.

## Severity

Websites & Applications - High (reported as Critical; downgraded because impact was limited to the friendship request flow).

## Changes

- Add `vulnerabilities/2026-07-01.md`
- Add entry to the Vulnerabilities Index in `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)