### PR TITLE
docs: add rca for marketplace non-mana erc20 bid vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To add new incidents use the date of the event as the Id with the following form
 - [2022-02-05](incidents/2022-02-05.md) Wearables not loading on some users backpack due to corrupted dropped wearable
 
 ## Vulnerabilities Index
+- [2026-07-20](vulnerabilities/2026-07-20.md) Marketplace accepts bids priced in an arbitrary ERC-20 that the UI presents to the seller as MANA
 - [2026-07-01](vulnerabilities/2026-07-01.md) Missing state-machine validation lets any user forge non-consensual friendships and bypass the ONLY_FRIENDS voice gate
 - [2026-06-08](vulnerabilities/2026-06-08.md) Parcel-restricted world collaborator can deploy to and delete scenes across the entire world
 - [2026-05-18](vulnerabilities/2026-05-18.md) Prompt injection in unity-explorer Claude PR review workflow

--- a/vulnerabilities/2026-07-20.md
+++ b/vulnerabilities/2026-07-20.md
@@ -1,0 +1,25 @@
+# July 20, 2026 - Marketplace accepts bids priced in an arbitrary ERC-20 that the UI presents to the seller as MANA
+
+|                          |              |
+| -----------------------: | :----------- |
+| **Reported on Immunefi** | July-20-2026 |
+|           **Mitigation** | July-20-2026 |
+|   **Solution Completed** | July-20-2026 |
+
+## Description
+
+- The marketplace off-chain trade system lets a bidder offer a "price" asset in exchange for an NFT. `TradeCreationSchema` (`src/ports/trades/schemas.ts`) validated an ERC-20 price asset's `contractAddress` only as a well-formed address, and `validateTradeByType` (`src/ports/trades/utils.ts`) accepted any asset of type `ERC20` as a valid bid price — it never required the chain's official MANA token.
+- No other layer restored the missing restriction. `POST /v1/trades` applies AuthChain wallet authentication and the schema, then forwards the body to `addTrade`, whose remaining checks (expiry, signer equality, structure, Estate fingerprint, signature validity, sent-NFT ownership) never constrain the payment token. The EIP-712 signature authenticates the attacker-chosen token rather than restricting it, and the persistence column is an unconstrained `varchar(42)`.
+- The public bid projection then discarded the token's identity: `getBidTradesQuery` (`src/ports/bids/queries.ts`) projected only the sent amount as `price`, and the public `Bid` object carried no payment-token field. The seller-facing web app therefore rendered every bid amount with the MANA symbol — including a MANA-denominated accept confirmation and a solvency check that reads the *bidder's MANA balance* — regardless of the real token, and never compared the hidden token against MANA before submitting the seller's accept transaction.
+- The deployed marketplace contract transfers a generic ERC-20 by calling `SafeERC20.safeTransferFrom` on the signed token address (only the `USD_PEGGED_MANA` asset type is forced to MANA). A token whose `transferFrom` returns `true` without moving any value passes that call, and execution continues to transfer the seller's ERC-721.
+- End to end: an attacker deploys a no-op ERC-20, then signs and posts a bid priced in it (holding enough real MANA only to satisfy the UI's bidder-balance check, never spending it). The bid surfaces in the item's offers as an attractive MANA-denominated offer. A seller who accepts it through the ordinary "accept bid" flow transfers their NFT and receives nothing of value. The transfer is irreversible and requires only the seller's normal, documented action; recovery depends on voluntary return by the attacker.
+
+## Severity
+
+Websites & Applications - High.
+
+Reported as Critical (irreversible transfer of the seller's NFT with no payment). Assessed as High because no value moves without the seller's own action — the attacker cannot complete the theft unless the victim accepts the misrepresented bid.
+
+## Solution
+
+[Reject any trade whose price asset is a non-MANA ERC-20](https://github.com/decentraland/marketplace-server/pull/367). `validateTradeByType` now requires a plain `ERC20` price asset's `contractAddress` to equal the chain's official MANA token (`getContract(ContractName.MANAToken, chainId)`, compared case-insensitively) for bids (`sent[0]`) and both public order types (`received[0]`); `USD_PEGGED_MANA` remains allowed because the contract resolves it to MANA at execution, and an unsupported chain is treated as invalid. Non-MANA prices are rejected before persistence with a new `InvalidTradePriceAssetError` mapped to HTTP 400, so a misrepresented bid can no longer be created. Retaining the payment-token identity in the bid API and `Bid` object, re-verifying it in the client before display and acceptance, and restricting generic ERC-20 at the contract layer are tracked as defense-in-depth follow-ups.


### PR DESCRIPTION
## Changes

- Add `vulnerabilities/2026-07-20.md` documenting the marketplace vulnerability where a bid could be priced in an arbitrary ERC-20 that the seller-facing UI rendered as MANA, allowing a seller who accepts the bid to transfer their NFT for no value.
- Link it at the top of the Vulnerabilities Index in the README.

Follows the existing RCA format (report source + dates table, Description, Severity, Solution). The fix shipped in decentraland/marketplace-server#367 (merged July 20, 2026).