### PR TITLE
docs: RCA 2026-07-22 places scene-thumbnail stored XSS

### DIFF
--- a/vulnerabilities/2026-07-22.md
+++ b/vulnerabilities/2026-07-22.md
@@ -1,0 +1,29 @@
+# July 22, 2026 - Scene thumbnail filename injects markup into the Places social endpoint (stored XSS / defacement)
+
+|                          |              |
+| -----------------------: | :----------- |
+| **Reported on Immunefi** | July-21-2026 |
+|           **Mitigation** | July-22-2026 |
+|   **Solution Completed** | July-22-2026 |
+
+## Description
+
+- A scene's `display.navmapThumbnail` is expected to name a content file, and the matching `content[].file` is documented as a relative path. Neither the deployed schema nor the content validators enforced that: `@dcl/content-validator`'s `embeddedThumbnail` (Catalyst / Genesis City scenes) and `worlds-content-server`'s `validateThumbnail` (worlds) only required a non-empty string that exactly matched some `content[].file`. An authorized publisher could therefore set both fields to a value shaped like an absolute URL that also carries HTML: `https://x"><script>...</script><meta name="y`, and the deployment was accepted.
+- Places ingests deployments and resolves the thumbnail to a content hash **only when the value does not start with `https://`** (`getThumbnailFromContentDeployment`, `src/entities/Place/utils.ts`). A `https://`-prefixed value was treated as a trusted external URL and kept verbatim, then stored into `Place.image` by `createPlaceFromContentEntityScene`. The equivalent world path stored `thumbnailUrl` into `World.image` via `handleWorldSettingsChanged`.
+- The public `/places/place/` and `/places/world/` social/OpenGraph routes passed `Place.image` / `World.image` to `replaceHelmetMetadata` (`decentraland-gatsby@8.4.6`), which interpolated the `image` value **unescaped** into a quoted `<meta ... content="...">` attribute and then reparsed the resulting string as HTML. Title and description were escaped; `image` and `url` were not. The crafted filename therefore broke out of the attribute and became a live element in `<head>`.
+- Result: an ordinary authorized publisher could persist attacker-chosen active markup that Places serves, from its own origin, to every browser that loads the crafted scene's public social URL — an unauthorized visual change of the page that remains across requests until the publisher redeploys safe metadata or moderation intervenes.
+- Precondition: only normal authorization to publish one scene (owning the target parcel or being its authorized operator). No internal role, victim action, scene-code execution, or third-party compromise is required. The demonstrated effect is the unauthorized visual change; the route is a social-metadata endpoint, so a visitor reaches the payload by opening the raw URL in a browser (link unfurlers do not execute JavaScript). The production Cloudflare WAF was not a mitigation — it blocked only payloads containing a literal `<script>` tag and inspected nothing on the serve path.
+
+## Severity
+
+Websites & Applications - Medium.
+
+Impact: defacing the sites, totally or partially, resulting in unauthorized visual changes of the site which could impact multiple users.
+
+## Solution
+
+Defense-in-depth across the deployment gate, ingestion, and render layers:
+
+- **Deployment gate (root cause).** Require `navmapThumbnail` to be a plain relative path before the embedded-file check, rejecting URI schemes, protocol-relative and root-absolute paths, leading/trailing whitespace, control characters, and the HTML-breakout characters `<`, `>` and `"`. Applied in the two independent validators — [`@dcl/content-validator`](https://github.com/decentraland/core-libs/pull/55) (Catalyst / Genesis City scenes) and [`worlds-content-server`](https://github.com/decentraland/worlds-content-server/pull/514) (worlds), which does not depend on the former.
+- **Render sink.** [Escape the `image`/`url` values and the metadata keys in `replaceHelmetMetadata`](https://github.com/decentraland/decentraland-gatsby/pull/1327) so every metadata value and key is contextually encoded before HTML insertion (published as `decentraland-gatsby@8.4.7`).
+- **Places.** [Sanitize thumbnails on ingestion and again at the social sink, and bump `decentraland-gatsby` to `8.4.7`](https://github.com/decentraland/places/pull/853). Attacker-reachable thumbnail values are parsed through `URL` and dropped unless they are safe `http(s)` URLs, both when writing `Place.image` / `World.image` and when rendering them in the social route, so already-persisted rows are protected at render time in addition to the sink-level escaping now provided by the upgraded dependency.


### PR DESCRIPTION
Adds the root-cause analysis for the stored XSS / defacement reported on Immunefi on July 21, 2026.

An authorized scene publisher could shape a scene's `navmapThumbnail` (and matching `content[].file`) as an absolute-URL-looking string carrying HTML. The content validators only required an exact filename match, Places kept `https://`-prefixed thumbnails verbatim in `Place.image`/`World.image`, and the `/places/place/` and `/places/world/` social routes rendered that value unescaped into a `<meta content="...">` attribute (`decentraland-gatsby@8.4.6`) — turning the filename into live markup served from the official Places origin.

Severity: Websites & Applications - Medium (defacing the sites, partially or totally; unauthorized visual changes affecting multiple users).

Fixed with defense-in-depth across the deployment gate, ingestion, and render layers; all PRs merged/ready and the services deploy today:
- deployment gate: [core-libs#55](https://github.com/decentraland/core-libs/pull/55), [worlds-content-server#514](https://github.com/decentraland/worlds-content-server/pull/514)
- render sink: [decentraland-gatsby#1327](https://github.com/decentraland/decentraland-gatsby/pull/1327) (published 8.4.7)
- ingestion + sink + dependency bump: [places#853](https://github.com/decentraland/places/pull/853)