### PR TITLE
docs: add rca for stored css defacement via vote rationale

### DIFF
--- a/vulnerabilities/2026-07-23.md
+++ b/vulnerabilities/2026-07-23.md
@@ -16,7 +16,7 @@
 
 ## Severity
 
-Websites & Applications - Low.
+Websites & Applications - Medium.
 
 Matches the Immunefi "defacing the sites, totally or partially, resulting in unauthorized visual changes of the site which could impact multiple users" clause, and the change is stored and served to every visitor of the affected page. Kept at the low end because qualifying requires at least 50,000 VP (≈ USD 3,500 at the time of the report), the impact is cosmetic only (no script execution, data exposure, or asset loss), and the blast radius is a single proposal page that self-heals on client-side navigation.
 

--- a/vulnerabilities/2026-07-23.md
+++ b/vulnerabilities/2026-07-23.md
@@ -1,0 +1,35 @@
+# July 23, 2026 - Stored CSS defacement of DAO proposal pages via unsanitized Snapshot vote rationale
+
+|                          |               |
+| -----------------------: | :------------ |
+| **Reported on Immunefi** | July-22-2026  |
+|           **Mitigation** | July-23-2026  |
+|   **Solution Completed** | Pending       |
+
+## Description
+
+- The proposal detail page renders a qualifying Snapshot vote's user-controlled `reason` as sanitized HTML. `VotingRationaleSection` passes reasons from votes with at least `REASON_THRESHOLD` VP (50,000 in production) into the shared `Comment` component, which sanitizes with `DOMPurify.sanitize(html, { USE_PROFILES: { html: true } })` and assigns the result to `dangerouslySetInnerHTML` (`governance-ui/src/components/Comments/Comment.tsx`).
+- DOMPurify's HTML profile strips `<script>` and event handlers but **retains `<style>` elements** and their CSS. A `<style>` in the DOM applies to the whole document regardless of where it is nested, so a rule such as `body:before { content:"…"; position:fixed; inset:0; z-index:2147483647 }` paints a full-viewport overlay.
+- The production governance site CSP permits inline styles — `style-src 'unsafe-inline'` in `definitions/src/sites/csp/governance.ts` — so the injected `<style>` is not blocked at the browser layer either.
+- A voter with at least 50,000 VP could therefore store a ~119-character rationale (within the 140-char reason limit) that installs page-wide CSS and replaces the visible proposal page. The reason is cached server-side and served to everyone, so the defacement is persistent and affects every visitor of that proposal page; visitors cannot clear it.
+- Scope is one proposal page per malicious eligible vote. The app is a React SPA, so navigating to any other route unmounts the `<style>` and the overlay disappears — this is not site-wide, and there is no script execution, account compromise, or asset loss. Reproduced against the pinned `dompurify@2.5.8` with the exact production sanitizer config (scripts stripped; the `<style>` block and its declarations survive intact).
+
+## Severity
+
+Websites & Applications - Low.
+
+Matches the Immunefi "defacing the sites, totally or partially, resulting in unauthorized visual changes of the site which could impact multiple users" clause, and the change is stored and served to every visitor of the affected page. Kept at the low end because qualifying requires at least 50,000 VP (≈ USD 3,500 at the time of the report), the impact is cosmetic only (no script execution, data exposure, or asset loss), and the blast radius is a single proposal page that self-heals on client-side navigation.
+
+## Solution
+
+[Neutralize the shared comment/rationale sink](https://github.com/decentraland/governance-ui/pull/252) in `governance-ui`:
+
+- Add `FORBID_TAGS: ['style', 'form', 'input', 'button', 'select', 'option', 'textarea']` and `FORBID_ATTR: ['style']` to the `DOMPurify.sanitize` call in `Comment.tsx`. This drops the `<style>` element and inline `style=` attribute that enabled the defacement (verified: the payload reduces to its leading text), and also removes form elements that DOMPurify's HTML profile otherwise keeps and that could render an in-page credential-phishing form. Legitimate Discourse "cooked" formatting (links, mentions, images, lists, emphasis) is preserved.
+- Render vote rationales as plain text via a new `plainText` prop on `Comment`, set by `VotingRationaleSection`. Vote reasons are free-text, not HTML, so they now render as escaped text and never reach the `dangerouslySetInnerHTML` sink at all. This also aligns the rationale display with the votes-list modal (`VoteListItem`), which already renders `reason` as plain text.
+
+The fix was consolidated into PR #252 (the security-hardening branch, which also hardens dangerous-scheme `href`s in the shared `Link` component); the earlier standalone style-only PR #253 is superseded.
+
+Follow-ups tracked separately (defense-in-depth, not required to close the defacement):
+
+- Tighten the governance CSP in `definitions/src/sites/csp/governance.ts` — drop `style-src 'unsafe-inline'`, and consider an `img-src` allowlist (currently `img-src https: data:`, which lets stored content load arbitrary remote images and leak every viewer's IP). Removing `'unsafe-inline'` requires auditing styled-components/emotion inline-style usage first.
+- Filter and rebuild any vote reasons already cached with a `<style>` block on the backend.


### PR DESCRIPTION
adds `vulnerabilities/2026-07-23.md`, the rca for the governance-ui stored css defacement.

## summary

a snapshot vote `reason` from a voter with >= 50,000 vp is rendered through the shared `Comment` dompurify sink (`USE_PROFILES: { html: true }` → `dangerouslySetInnerHTML`). that profile keeps `<style>`, and the governance csp allows `style-src 'unsafe-inline'`, so a stored reason could install page-wide css and deface the proposal page for every visitor (persistent, single page).

- severity: websites & applications - low (cosmetic, single page, gated behind ~usd 3,500 of vp)
- fix: governance-ui pr #252 (forbid `<style>`/form tags in the sanitizer + render rationales as plain text)
- follow-ups noted: tighten csp `style-src`/`img-src`; rebuild cached reasons

## note

`solution completed` is left **pending** — the fix pr (#252) is still open. update the date on merge/deploy.