### PR TITLE
docs: RCA — unauthorized third-party emote deployment hijacks an approved wearable's pointer

### DIFF
--- a/vulnerabilities/2026-07-30.md
+++ b/vulnerabilities/2026-07-30.md
@@ -1,0 +1,33 @@
+# July 30, 2026 - Unauthorized third-party emote deployment hijacks an approved third-party wearable's pointer
+
+|                          |               |
+| -----------------------: | :------------ |
+| **Reported on Immunefi** | July-23-2026  |
+|           **Mitigation** | July-30-2026  |
+|   **Solution Completed** | July-30-2026  |
+
+## Description
+
+- Decentraland third-party ("linked") wearables and emotes are deployed to Catalysts by proving that the entity metadata hash is a leaf of an approved on-chain merkle root (ADR-62 / ADR-55). The wearable and emote deployment paths share the same access check, `thirdPartyAssetValidateFn` (`@dcl/content-validator`, `validations/access/{on-chain,subgraph}/third-party-asset.ts`), which only verifies merkle-root membership of the caller-supplied leaf.
+- The binding of that leaf to the actually-served content lived **only** on the wearable item-validation path (`thirdPartyWearableMerkleProofContentValidateFn`): it enforced that `metadata.id` equals the deployment pointer and that the uploaded files exactly match the merkle-committed `content` map. The emote path (`emoteValidateFn`) had no equivalent binding.
+- A third-party wearable leaf is hashed over `merkleProof.hashingKeys` = `[id, name, description, i18n, data, image, thumbnail, metrics, content]` — it does **not** commit the entity `type` or `emoteDataADR74`. An attacker could therefore copy a live, approved third-party wearable's public proof and committed metadata, add a schema-valid `emoteDataADR74`, attach arbitrary PNG/GLB files, build an `emote` entity at the wearable's official pointer, and sign it with any freshly-generated key. The on-chain root check, the entity-hash recomputation, and the signature check all pass — no collection ownership, curator role, privileged key, or blockchain transaction is required, and no victim interaction is needed.
+- On deployment, Catalyst accepts the emote with attacker-chosen files at the wearable's pointer. Because the `active_pointers` table is keyed only by pointer, the third-party/collection listing (served from the third-party materialized view) resolves that pointer to the attacker emote and its content after the next MV refresh. The overwrite bookkeeping is `entity_type`-scoped, so the original wearable deployment is not marked deleted; on the direct per-pointer read the wearable and the emote coexist as active and single-entity endpoints resolve non-deterministically. (The reporter's "sole active result on every read" claim is therefore inaccurate for the direct-pointer query, but the integrity violation — attacker content served at another publisher's protected pointer — holds.)
+- Net: an unprivileged, unauthorized signer can alter the content Catalyst serves for another publisher's approved third-party item. A legitimate publisher can restore the pointer by redeploying, but any attacker can replace it again while the item's leaf remains in the approved root. No ownership transfer, minting, fund loss, blockchain-state change, or permanent deletion is involved.
+
+## Severity
+
+Websites & Applications - Medium.
+
+Unauthorized modification of content the platform serves for a protected, third-party-owned pointer — it crosses into another publisher's official item rather than an attacker-owned collection or preview, and the replacement is stored and served network-wide. Kept below high because there is no code execution, account compromise, asset loss, or blockchain-state change; the impact is content-integrity only and is recoverable by the legitimate publisher redeploying. Exploitation requires no privilege, so the integrity guarantee for approved third-party items was effectively absent for the emote entity type.
+
+## Solution
+
+[Bind third-party emotes to their approved merkle leaf](https://github.com/decentraland/core-libs/pull/57) in `@dcl/content-validator` (merged; released as `@dcl/content-validator@7.4.2`):
+
+- Add `thirdPartyEmoteMerkleProofContentValidateFn`, the emote counterpart of the wearable binding, to `emoteValidateFn`. For a third-party emote it enforces that `metadata.id` matches the pointer, that the uploaded files exactly match the merkle-committed `content` map, and that the proof commits `emoteDataADR74` — the last check makes replaying a wearable leaf (whose keys omit `emoteDataADR74`) impossible.
+- Require `id`, `content` (plus `data` for wearables and `emoteDataADR74` for emotes) to be present in `merkleProof.hashingKeys` for both item types, so those fields are actually committed by the leaf instead of being trusted from attacker-supplied metadata. The shared logic was extracted into `thirdPartyMerkleProofContentValidateFn` so the two paths cannot drift.
+- Also move the outfits pointer-ownership check into the access layer, matching profile/store (defense-in-depth; not a live gap — the same check already ran in the stateless pipeline).
+
+Verified against production data before shipping: every sampled live third-party wearable (adidas-virtual-gear, dolcegabbana-disco-drip, cryptoavatars, nft-studios, baby-doge-coin) commits `id`/`content`/`data` in its `hashingKeys` and its `id` matches its pointer, so the stricter validation does not reject any legitimate item. The official Builder derives `hashingKeys` from the entity metadata keys and never produces third-party emotes, so no existing deployment is affected.
+
+Rollout: the `@dcl/content-validator` bump to 7.4.2 landed in [catalyst#1952](https://github.com/decentraland/catalyst/pull/1952) and shipped to production in Catalyst release 8.0.3.


### PR DESCRIPTION
adds the rca for the third-party emote content-binding issue (reported on immunefi july-23, mitigated + solved july-30).

- validation fix (core-libs): https://github.com/decentraland/core-libs/pull/57 → `@dcl/content-validator@7.4.2`
- catalyst content-validator bump: https://github.com/decentraland/catalyst/pull/1952 (shipped to production in catalyst release 8.0.3)

file: `vulnerabilities/2026-07-30.md`.