### PR TITLE
Add RCAs for three Bevy Explorer web client vulnerability reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ To add new incidents use the date of the event as the Id with the following form
 - [2022-02-05](incidents/2022-02-05.md) Wearables not loading on some users backpack due to corrupted dropped wearable
 
 ## Vulnerabilities Index
+- [2026-08-07](vulnerabilities/2026-08-07-3.md) Unauthenticated worker bootstrap re-handed the engine's shared memory in the Bevy Explorer web client
+- [2026-08-07](vulnerabilities/2026-08-07-2.md) A URL query parameter selected the trusted super-user scene in the Bevy Explorer web client
+- [2026-08-07](vulnerabilities/2026-08-07.md) Scene sandbox escape reaches same-origin capabilities and persisted session credentials in the Bevy Explorer web client
 - [2026-07-26](vulnerabilities/2026-07-26.md) Client-supplied `asset_pack_id` lets any user insert assets into another user's Builder asset pack
 - [2026-07-23](vulnerabilities/2026-07-23-2.md) Missing third-party manager authorization on the Builder collection publish route
 - [2026-07-20](vulnerabilities/2026-07-20.md) Marketplace accepts bids priced in an arbitrary ERC-20 that the UI presents to the seller as MANA

--- a/vulnerabilities/2026-08-07-2.md
+++ b/vulnerabilities/2026-08-07-2.md
@@ -1,0 +1,45 @@
+# August 7, 2026 - A URL query parameter selected the trusted super-user scene in the Bevy Explorer web client
+
+|                          |                 |
+| -----------------------: | :-------------- |
+| **Reported on Immunefi** | August-03-2026  |
+|           **Mitigation** | August-04-2026  |
+|   **Solution Completed** | August-07-2026  |
+
+Related: [2026-08-07](2026-08-07.md) and [2026-08-07-3](2026-08-07-3.md) — separate reports
+received in the same window against the same client.
+
+## Description
+
+The Bevy Explorer web client boots one privileged "super-user" scene that owns the HUD and is granted the full `SystemApi`. Which scene fills that role was selectable from the page URL.
+
+- **Root cause: a trust decision was taken from attacker-controlled input.** `?systemScene=` was read from the query string (`react-web/src/lib/bootMode.ts`), passed unvalidated into the engine boot config, and became the startup scene flagged `super_user: true`. A query parameter is input, not a trust signal.
+- **The privilege it conferred was total.** System scenes short-circuit the permission check before any permission is consulted (`crates/scene_runner/src/permissions.rs`) — there is no subset of permissions a system scene is denied. On top of that, the `SystemApi` exposes restoring the user's stored login without approval, and signing authenticated Decentraland requests for arbitrary destinations.
+- **Net effect: a crafted link on our own origin was a session takeover with a single click.** No sandbox escape was involved; this is a distinct boundary from [the scene sandbox escape](2026-08-07.md) and would have remained open had that one been fixed alone. Setting the parameter also implied auto-login and suppressed the HUD, so the victim saw no sign-in step and no UI that might have signalled the substitution.
+- **Secondary, same shape:** `?portables=` builds startup scenes from the query string in the same way. Those are not super-user, so they are not a privilege escalation, but a crafted link still auto-loads attacker code into an authenticated session with one click.
+
+## Severity
+
+None — out of scope.
+
+The Bevy Explorer web client is not among the assets listed in the bounty program, so no program severity rating applies. The report was triaged, remediated and discretionarily rewarded regardless.
+
+That classification is about scope, not validity. The defect was real and reproduced against the shipped build: one click on a crafted link handed arbitrary remote code a total permission bypass plus credential restore inside the victim's session. Against an in-scope asset this would have rated high. No blockchain state, funds or on-chain ownership were reachable.
+
+## Solution
+
+[Warn before a link picks its own super-user scene](https://github.com/decentraland/bevy-explorer/pull/1052) — `?systemScene=` is now checked against an exact-match trust list before it can take effect: the shipped bridge scene, first-party UI worlds, and loopback hosts for `sdk-commands start`, which is the parameter's legitimate use and which a link cannot make someone else's machine serve. Matching is exact — a suffix test would accept `tortilla.dcl.eth.example.com`, and a prefix test on the worlds URL would accept a path traversal out of it. Anything not on the list renders an interstitial before the engine boots.
+
+Placement matters and is part of the fix: the gate is an early return above the HUD, so the engine never initialises with the hostile config, auto-login never fires, and the parameter's own `hideHud` cannot suppress the very warning that exists to flag it. Consent is never taken from the URL — there is no parameter that dismisses the gate.
+
+**The trust list is what closes this report, not the interstitial.** The report's own impact class is "with up to one click of user interaction", so a dialog the user clicks through does not move it out of that class — and click-through is high for phishing-shaped links, where the user arrives *wanting* the link to work. The interstitial is a proportionate bar for the untrusted-but-plausible cases; it is not the boundary.
+
+### Residual work
+
+Tracked as follow-ups. The reported path is closed by the trust list above; these narrow what a super-user scene can do if one is ever reached by another route.
+
+- **Split the `super_user` bit.** It currently means both "may drive the HUD bridge" and "bypasses every permission check, may restore credentials, may sign requests". A custom HUD needs only the first. Splitting it would let `?systemScene=` be demoted from a trust list to a consent prompt — the version of this feature that is safe to keep — and limits the blast radius of any future super-scene compromise.
+- **Require explicit user intent to restore stored credentials**, rather than accepting it as a call from any super-user scene. This is the step that converts "attacker ran a scene" into "attacker is you", and is worth doing independently of everything above.
+- **Restrict authenticated request signing to known service origins.**
+- **Apply the same gating to `?portables=`.**
+- **Regression tests** for a remote `systemScene` URL rejected in development and any `systemScene` ignored in production builds. Existing coverage passes only because its fixture happens to be a loopback URL.

--- a/vulnerabilities/2026-08-07-3.md
+++ b/vulnerabilities/2026-08-07-3.md
@@ -1,0 +1,38 @@
+# August 7, 2026 - Unauthenticated worker bootstrap re-handed the engine's shared memory in the Bevy Explorer web client
+
+|                          |                 |
+| -----------------------: | :-------------- |
+| **Reported on Immunefi** | August-04-2026  |
+|           **Mitigation** | August-05-2026  |
+|   **Solution Completed** | August-07-2026  |
+
+Related: [2026-08-07](2026-08-07.md) and [2026-08-07-2](2026-08-07-2.md) — separate reports
+received in the same window against the same client.
+
+## Description
+
+The Bevy Explorer web client compiles the engine wasm once on the main thread and shares one `WebAssembly.Memory` with its workers. Each scene runs in a dedicated Web Worker that hosts a threaded wasm instance over that shared memory.
+
+- **Root cause: a bootstrap handshake with no state transition.** `deploy/web/engine/engine.js` posted the compiled module and the shared memory in response to a `READY` message from the worker, with no nonce, no phase check and no one-time latch. The legitimate `READY` is emitted once at module evaluation, before any scene code exists — so any *later* `READY` could only originate from code that ran afterwards, and it was answered identically. The payload is a live handle to the engine heap, not a copy. The asset loader and asset processor workers used the same unlatched pattern.
+- **Reachability.** Scene code shares the sandbox worker's realm, but `postMessage` and `self` are not exposed to it: neither is on the sandbox allowlist and neither is injected into the scene scope, so both resolve to `undefined` through the proxy. Reaching the real `postMessage` first requires escaping the identifier sandbox, reported separately as [the scene sandbox escape](2026-08-07.md). This report is a downstream leg of that one rather than an independently reachable path, and closing it closes this.
+- **The submitted proof did not demonstrate the claimed impact.** It replaced `window.Worker` on the main thread with a substitute class, so no sandbox worker was instantiated and no scene code executed — the actor was the trusted host page, which already reaches the same memory directly and needs no handshake. The session key it then "recovered" from the heap dump had been written into that buffer by the harness itself, at a fixed offset, before upload. Nothing in the submission established that session key material is resident in the shared heap in recoverable form, which was the load-bearing step for the claimed account-takeover impact.
+- The defect was fixed on its own merits as a genuine missing latch, independently of the proof.
+
+## Severity
+
+None — out of scope.
+
+The Bevy Explorer web client is not among the assets listed in the bounty program, so no program severity rating applies. The report was triaged, remediated and discretionarily rewarded regardless.
+
+Separately from scope, this is the weakest of the three reports on its own merits: it is not reachable without [the scene sandbox escape](2026-08-07.md), and the submission did not establish the impact it claimed. Against an in-scope asset it would have rated low. The underlying observation — that the handshake had no one-time transition — was accurate and worth fixing.
+
+## Solution
+
+[Send worker init payloads at spawn instead of on request](https://github.com/decentraland/bevy-explorer/pull/1054) — the compiled module and shared memory are now posted unprompted when the worker is created. A worker queues messages posted before it installs a listener, so nothing needs to ask for the payload and there is no request left to forge. The handler is dropped at `INIT_COMPLETE`, which the worker posts before it builds the scene JS context, so the main thread is not listening while scene code runs. The retry path spawns a replacement wired the same way, so an init failure still recovers. The asset loader and asset processor were changed identically.
+
+Note the limit of this fix, so it is not read as more than it is: the scene worker holds the engine's shared heap **by design** — that is what threaded wasm is, and the heap is in the scene's realm before the scene's first statement. Removing the handshake removes one handle to it, as [inlining the wasm glue](https://github.com/decentraland/bevy-explorer/pull/1044) removed another. The boundary that actually matters here is [the scene sandbox escape](2026-08-07.md); this entry should not be taken to imply the class is closed by itself.
+
+### Residual work
+
+- **Regression test** asserting that a `READY` posted from inside the worker realm after boot receives no payload.
+- The broader hardening that governs this path is tracked in [2026-08-07](2026-08-07.md).

--- a/vulnerabilities/2026-08-07.md
+++ b/vulnerabilities/2026-08-07.md
@@ -1,0 +1,49 @@
+# August 7, 2026 - Scene sandbox escape reaches same-origin capabilities and persisted session credentials in the Bevy Explorer web client
+
+|                          |                 |
+| -----------------------: | :-------------- |
+| **Reported on Immunefi** | August-03-2026  |
+|           **Mitigation** | August-04-2026  |
+|   **Solution Completed** | August-07-2026  |
+
+Related: [2026-08-07-2](2026-08-07-2.md) and [2026-08-07-3](2026-08-07-3.md) — separate reports
+received in the same window against the same client.
+
+## Description
+
+The Bevy Explorer web client runs each Decentraland scene as untrusted JavaScript inside a dedicated Web Worker. Scene code is compiled through a `Function` wrapper whose scope is a `Proxy` over a curated allowlist of globals (`deploy/web/engine/sandbox_worker.js`), and one privileged "super-user" scene owns the HUD bridge and the `SystemApi`.
+
+- **Root cause: an in-realm JavaScript allowlist was being used as a privilege boundary.** The proxy is only consulted for *identifier lookups inside the wrapped scene source*. It has no reach into a function body compiled by the native `Function` constructor, and it does not intercept names it never shadows. Two independent consequences followed, both verified against the shipped build:
+  - Every allowlisted intrinsic is a live reference to the real one, so `Object.constructor`, `(()=>{}).constructor` and `Function` itself all return the genuine worker global. Removing individual entries from the allowlist does not help — closing that route would mean removing `Object`, `Array`, `String`, `Promise`, i.e. removing JavaScript.
+  - The generated preamble declares `const X = globalThis.X` only for allowlisted names, and there is no `with`. Any global *not* on the list, named as a bare identifier, resolved straight up the scope chain to the real worker global — no constructor trick required. This is the sharper of the two and was not the mechanism described in the report.
+- **Reported impact — reaching the HUD bridge.** With the real worker global in hand, an ordinary scene could obtain `BroadcastChannel` and address the HUD bridge, which listens on a fixed, guessable channel name and dispatched purely on message shape with no sender check. That let an untrusted scene drive privileged UI actions in the logged-in user's session.
+- **Found during triage — persisted credentials in OPFS.** The same escape also exposed the origin's storage APIs. The client keeps `config.json` in OPFS, and it persists `previous_login` containing the user's ephemeral private key and full delegation chain. `navigator.storage` was reachable from ordinary scene code, and the allowlisted `fetch` provided exfiltration. This was not part of the submission and is materially more severe than what the report demonstrated: it yields offline, persistent impersonation from attacker infrastructure until the key expires, with no bridge and no open session required. It was folded into the same fix window.
+- A related route existed alongside these: scene code could re-`import` the wasm glue module by URL and receive the engine's *initialised* instance, shared heap included.
+
+## Severity
+
+None — out of scope.
+
+The Bevy Explorer web client is not among the assets listed in the bounty program, so no program severity rating applies. The report was triaged, remediated and discretionarily rewarded regardless.
+
+That classification is about scope, not validity. The defect was real and reproduced against the shipped build: any deployed scene could act inside a logged-in user's session with no user interaction beyond entering the world, and the storage path reached live session key material. Against an in-scope asset this would have rated high. No blockchain state, funds or on-chain ownership were reachable.
+
+## Solution
+
+The fixes replace allowlist filtering with capability removal — nothing that matters is left in the realm for an escape to find.
+
+[Remove BroadcastChannel from the ordinary scene sandbox](https://github.com/decentraland/bevy-explorer/pull/1043) — capture the constructor at module load, then `delete` `BroadcastChannel`, `Worker` and `SharedWorker` from the real worker global before any scene code is compiled. `Worker` goes too: a nested worker is a fresh realm whose global would have `BroadcastChannel` back, undoing the deletion in one line. The trusted super-user scene receives the captured constructor through its injected context instead, so the removal is realm-level and the privileged consumer is unaffected.
+
+[Remove same-origin storage APIs from the scene sandbox worker](https://github.com/decentraland/bevy-explorer/pull/1051) — remove `navigator.storage`, `navigator.storageBuckets`, `indexedDB` and `caches` from the worker, walking the prototype chain because these are prototype accessors that a plain `delete` silently fails to remove while still returning `true`. Scene `localStorage` keeps working: the Rust side now takes a handle to just the `local_storage/` subtree during init, and that handle stays live after the accessor is gone. This closes the credential path found during triage.
+
+[Inline the wasm glue into the sandbox worker bundle](https://github.com/decentraland/bevy-explorer/pull/1044) — bundling makes the glue's exports ordinary module-scope bindings, so a scene importing the worker entry by URL gets an empty namespace object rather than the live initialised instance.
+
+Also corrected the comments that presented the allowlist as a security control, so a future change does not re-add a capability to it on the assumption that it withholds anything.
+
+### Residual work
+
+Defence in depth against a future capability leak; not required to close the reported path.
+
+- **Move the HUD bridge from a named `BroadcastChannel` to a transferred `MessagePort`**, so bridge access is held rather than guessed. A worker never handed a port has no reachable path to the HUD, escaped global or not. Needs coordination with the editor host, which consumes the same sandbox.
+- **Treat the bridge protocol as untrusted input** — validate message shapes, and correlate permission responses on a nonce the engine mints and never echoes to scenes.
+- **Regression tests** asserting an ordinary scene cannot reach these globals by any constructor route, and that the super-user scene still can.


### PR DESCRIPTION
## Summary

Adds one RCA per report received against the Bevy Explorer web client, plus three README index lines.

| File | Issue |
| --- | --- |
| `vulnerabilities/2026-08-07.md` | Scene sandbox escape reaches same-origin capabilities and persisted session credentials |
| `vulnerabilities/2026-08-07-2.md` | A URL query parameter selected the trusted super-user scene |
| `vulnerabilities/2026-08-07-3.md` | Unauthenticated worker bootstrap re-handed the engine's shared memory |

Each entry stands alone and cross-links the other two. They are genuinely distinct boundaries — the query-parameter issue needs no sandbox escape at all and would have remained open had the escape been fixed alone, while the worker bootstrap is only reachable *through* the escape. Each entry says which.

The first entry also documents a storage path that was in no report: the same escape reached OPFS, where the client persists the user's ephemeral session key. Found during triage, more severe than what was reported, fixed in the same window.

All fixes are merged on `main`: bevy-explorer #1043, #1044, #1051, #1052, #1054.

Following the convention in `2026-07-26.md`, the entries carry no report ids, no tracker links and no reporter identification — the repo is public, so the metadata table is the only Immunefi reference.

## What could break

Nothing functional — documentation only.

Three content calls worth a reviewer's eye:

- **Severity is recorded as None — out of scope** on all three. The client is not a listed bounty asset, so no program rating applies. Each entry is explicit that this is a scope classification and not a judgement on validity, and states what it would have rated against an in-scope asset (high, high, low). All three were rewarded discretionarily.
- **The query-parameter entry does not claim the interstitial closes it.** The exact-match trust list is what closes it; the dialog is a proportionate bar, not a boundary, since that report's own impact class permits one click. Residual hardening is listed as follow-up rather than presented as done.
- **The worker-bootstrap entry states the limit of its own fix.** The scene worker holds the engine heap by design under threaded wasm, so removing the handshake removes one handle rather than closing the class. Worth keeping so a future reader does not treat it as having settled the boundary.

## How to test

- All three follow `vulnerabilities/template.md` (table, Description, Severity, Solution).
- Cross-links between the three entries resolve; every linked bevy-explorer PR is public and merged.
- No `bugs.immunefi.com` links or report ids anywhere in the diff.
- README index carries three `2026-08-07` lines at the top of the vulnerabilities list, matching the repo's same-day suffix convention.