### PR TITLE
docs: RCA 2026-08-11 case-sensitive scene-signer check in signed-fetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# RCA repository
+
+Markdown only — no build, test, lint or format tooling. `/ship-it` skips Step 4a–4d here by design.
+
+## Writing an RCA
+
+- One file per incident: `vulnerabilities/YYYY-MM-DD.md`, suffixed `-2`, `-3` when a
+  date carries more than one report. Start from `vulnerabilities/template.md`.
+- Spell the month out in full, in both the `# ` heading and the metadata table:
+  `August-06-2026`, not `Aug-06-2026`. The template's `Month-DD-YYYY` placeholder
+  reads as an abbreviation and has produced that drift before.
+- Link related incidents by relative path, e.g. `[2026-07-23](2026-07-23-2.md)`.

--- a/vulnerabilities/2026-08-11.md
+++ b/vulnerabilities/2026-08-11.md
@@ -1,0 +1,26 @@
+# August 11, 2026 - Case-sensitive scene-signer check in signed-fetch lets a scene act as the visiting user
+
+|                          |                |
+| -----------------------: | :------------- |
+| **Reported on Immunefi** | August-06-2026 |
+|           **Mitigation** | August-11-2026 |
+|   **Solution Completed** | August-11-2026 |
+
+## Description
+
+- First-party services reject requests signed on a scene's behalf by checking the signed-fetch metadata `signer` against `decentraland-kernel-scene`, the value the explorers stamp when they sign for a scene (ADR-289). Each service implemented this check itself (for example, builder-server's `decodeAuthChain`).
+- The check compared the `signer` case-sensitively, while the AuthChain signature is verified over a payload the middleware lowercases. A scene-signed request delivered with a mixed-case `signer` therefore passed the check while its signature still verified — the authorization check and the signature verification read the same field differently. It is not a signature forgery: the signature is the visitor's genuine one, and only the metadata casing differs.
+- The same check was reimplemented across builder-server, worlds-content-server, marketplace-server, auth-server, world-storage-service, and comms-gatekeeper, so the defect existed in all of them. Because the explorers produce signed requests on a visiting player's behalf, any scene a player walked into could act as that player against these endpoints with no click, wallet prompt, or visible action. Reachable impact was confined to off-chain data and denial — for example, altering or destroying a creator's unpublished builder content, or gaining persistent deployment rights on a victim's world; on auth-server and world-storage-service a second, unforgeable check behind each endpoint meant no impact was realized.
+- Nothing on-chain was reachable: no theft of funds, MANA, or NFTs, no minting, no ownership transfer, and no access to published on-chain collections. A legitimate owner can recover affected off-chain content by re-editing or redeploying.
+
+## Severity
+
+Websites & Applications - Critical.
+
+## Solution
+
+Fixed in `@dcl/crypto-middleware` `verifyMetadata`, which runs before any service's `metadataValidator`, so it closes the defect for every service at once: reject a non-canonical value for the guarded fields (`signer`, `intent`), trimmed and lowercased, with hex addresses exempt for EIP-55 checksum casing. Released as `@dcl/crypto-middleware@5.1.0`.
+
+builder-server additionally normalizes its own scene-signer check. All affected services — builder-server, worlds-content-server, marketplace-server, auth-server, world-storage-service, and comms-gatekeeper — were bumped to the fixed package and redeployed.
+
+Immunefi report #87537.


### PR DESCRIPTION
## Description

Adds the RCA for Immunefi report #87537: first-party services compared the signed-fetch `signer` metadata against `decentraland-kernel-scene` case-sensitively, while the AuthChain signature was verified over a payload the middleware lowercased. A scene-signed request carrying a mixed-case `signer` therefore passed the authorization check with a genuinely valid signature — the check and the verification read the same field differently. Because the check was reimplemented per service, the defect existed in builder-server, worlds-content-server, marketplace-server, auth-server, world-storage-service and comms-gatekeeper.

Also adds a root `AGENTS.md`, since the repo had no meta-file: it records the RCA file-naming scheme, the full-month date format the metadata table uses, and the relative-path cross-linking convention.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- `vulnerabilities/2026-08-11.md` — new RCA covering description, severity (Websites & Applications - Critical) and the solution: `@dcl/crypto-middleware@5.1.0` rejects non-canonical values for the guarded `signer` and `intent` fields in `verifyMetadata`, which runs ahead of every service's own `metadataValidator`, so one release closes it for all six services.
- `AGENTS.md` — new; RCA conventions for this repo.

## How to Test

1. Read `vulnerabilities/2026-08-11.md` and check it against `vulnerabilities/template.md`: the `# {Month DD, YYYY} - {Title}` heading, the three-row metadata table, and the `Description` / `Severity` / `Solution` sections.
2. Confirm the dates match the format used by the recent RCAs (`August-06-2026`, not `Aug-06-2026`).
3. Confirm the technical account matches Immunefi report #87537 and the `@dcl/crypto-middleware@5.1.0` release.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [ ] Added or updated tests where applicable
- [ ] Existing tests pass locally
- [x] Updated documentation if needed
- [x] No new warnings or console errors introduced

Markdown-only repo: no test or lint tooling exists, so those two boxes do not apply.

## Related Issues

Immunefi report #87537.

## Screenshots

N/A